### PR TITLE
Add regexp support, taken from github.com/advance512/yaml/

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gigforks/yaml"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"net"
 	"os"
 )


### PR DESCRIPTION
Unmarshal all encountered YAML values with keys
that match the regular expression into the tagged field of a
struct, which must be a map or a slice of a type that the YAML
value should be unmarshaled into. [Unmarshaling only]

Bugs:
*  When a type implementing UnmarshalYAML calls the the unmarshaler func()
   to unmarshal to a specific type, which fails, followed by it
   calling the func() again with a different output value which
   suceeds, the YAML unmarshaling process still failed. Issue was
   d.terrs == nil check, but not len(d.terrs) == 0

Tests:
*  Lots of new tests for the
*  regexp flag - regexp
*  unmarshaling into maps, slices, regexp priority etc.